### PR TITLE
src/config.py: Update pydantic to pydantic-settings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ gunicorn
 httpx
 itsdangerous
 black
+pydantic-settings
 # Temporarily, using teuthology without monkey patching the thread
 git+https://github.com/VallariAg/teuthology@teuth-api#egg=teuthology[test]
 # Original: git+https://github.com/ceph/teuthology#egg=teuthology[test]

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class APISettings(BaseSettings):
@@ -7,19 +7,11 @@ class APISettings(BaseSettings):
     Class for API settings.
     """
 
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
     PADDLES_URL: str = "http://paddles:8080"
     # TODO: team names need to be changed below when created
     admin_team: str = "ceph"  # ceph's github team with *sudo* access to sepia
     teuth_team: str = "teuth"  # ceph's github team with access to sepia
-
-    class Config:
-        """
-        Class for Config.
-        """
-
-        # pylint: disable=too-few-public-methods
-        env_file = ".env"
-        env_file_encoding = "utf-8"
 
 
 @lru_cache()


### PR DESCRIPTION
In the release of `pydantic` version 2, the developers have created a separate library for settings and config class called `pydantic-settings`, more information can be found here: https://docs.pydantic.dev/latest/usage/pydantic_settings

This PR adds `pydantic-settings` as a dependency in requirements.txt and update from `pydantic` in `src/config.py`