### PR TITLE
.github/workflows/signed_commit.yml: Create CI for checking signed commits

### DIFF
--- a/.github/workflows/signed_commit.yml
+++ b/.github/workflows/signed_commit.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check for commit trailers
         run: |
-          chmod +x ./scripts/signed.sh
-          ./scripts/signed.sh
+          chmod +x ./gh-actions/signed.sh
+          ./gh-actions/signed.sh
         shell: bash

--- a/.github/workflows/signed_commit.yml
+++ b/.github/workflows/signed_commit.yml
@@ -1,0 +1,18 @@
+name: Signed Commit CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for commit trailers
+        run: |
+          chmod +x ./scripts/signed.sh
+          ./scripts/signed.sh
+        shell: bash

--- a/gh-actions/signed.sh
+++ b/gh-actions/signed.sh
@@ -1,0 +1,5 @@
+trailer=$(git log -1 --no-merges $commit --pretty='%B' | git interpret-trailers --parse 2>&1)
+if [[ $trailer != Signed-off-by:* ]]; then
+    printf '%s\n' "Commit is not signed, use git commit --amend --signoff" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes #6 by creating a GitHub Actions CI that runs a bash script for checking whether the commit made by the user was signed or not. The script ignores merge commits as they generally don't have a `Signed-off-by:` trailer in the commit.