### PR TITLE
./github/workflows/signed.yaml: Create CI for checking signed commits

### DIFF
--- a/.github/workflows/signed.yaml
+++ b/.github/workflows/signed.yaml
@@ -1,0 +1,15 @@
+name: Signed Commit CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for commit trailers
+        run: |
+          chmod +x ./signed.sh
+          ./signed.sh
+        shell: bash
+        working-directory: ./gh-actions

--- a/gh-actions/signed.sh
+++ b/gh-actions/signed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+trailer=$(git log -1 --no-merges $commit --pretty='%B' | git interpret-trailers --parse 2>&1)
+if [[ $trailer != Signed-off-by:* ]]; then
+    printf '%s\n' "Commit is not signed, use git commit --amend --signoff" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes #6 using a bash script that checks for `Signed-off-by:` trailer in git commits. The script does not check the merge commits as they generally don't have the `Signed-off-by:` trailer.