### PR TITLE
src/routes: Update pydantic dict() to model_dump()

### DIFF
--- a/src/routes/kill.py
+++ b/src/routes/kill.py
@@ -26,5 +26,5 @@ def create_run(
     or else it will SyntaxError: non-dafault
     argument follows default argument error.
     """
-    args = args.dict(by_alias=True)
+    args = args.model_dump(by_alias=True)
     return run(args, logs, access_token, request)

--- a/src/routes/suite.py
+++ b/src/routes/suite.py
@@ -20,5 +20,5 @@ def create_run(
     dry_run: bool = False,
     logs: bool = False,
 ):
-    args = args.dict(by_alias=True)
+    args = args.model_dump(by_alias=True)
     return run(args, dry_run, logs, access_token)


### PR DESCRIPTION
`.dict()` method for converting a pydantic BaseModel to a dictionary is deprecated. This PR updates it to the new method, `.model_dump()`