### PR TITLE
Configure developement setup for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,8 @@ RUN apt-get update && \
 
 COPY .teuthology.yaml /root
 WORKDIR /teuthology_api
-COPY requirements.txt *.env /teuthology_api/
+COPY requirements.txt *.env start_container.sh /teuthology_api/
 RUN pip3 install -r requirements.txt
 COPY . /teuthology_api/
 
-WORKDIR /teuthology_api/src
-ENTRYPOINT gunicorn -c /teuthology_api/gunicorn_config.py main:app
+CMD sh /teuthology_api/start_container.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ A REST API to execute [teuthology commands](https://docs.ceph.com/projects/teuth
         build:
           context: ../../../teuthology-api
         ports:
-            - 8082:8082
+            - 8082:8080
+        environment: 
+            TEUTHOLOGY_API_SERVER_HOST: 0.0.0.0
+            TEUTHOLOGY_API_SERVER_PORT: 8080
+            PADDLES_URL: http://localhost:8080
         depends_on:
             - teuthology
             - paddles
@@ -32,7 +36,18 @@ A REST API to execute [teuthology commands](https://docs.ceph.com/projects/teuth
         healthcheck:
           test: [ "CMD", "curl", "-f", "http://0.0.0.0:8082" ]
     ```
-5. Follow teuthology development setup instructions from [here](https://github.com/ceph/teuthology/tree/main/docs/docker-compose).
+
+    [optional] For developement use:
+    Add following things in `teuthology_api` container:
+    ```
+    teuthology_api:
+        environment: 
+            DEPLOYMENT: development
+        volumes: 
+            - ../../../teuthology-api:/teuthology_api/:rw
+    ```
+    `DEPLOYMENT: development` would run the server in `--reload` mode (server would restart when changes are made in `/src` dir) and `volumes` would mount host directory to docker's directory (local changes would reflect in docker container). 
+3. Follow teuthology development setup instructions from [here](https://github.com/ceph/teuthology/tree/main/docs/docker-compose).
 
 ## Documentation
 

--- a/gh-actions/start.sh
+++ b/gh-actions/start.sh
@@ -5,15 +5,20 @@ if [ ! -d "$folder" ] ; then
     git clone https://github.com/ceph/teuthology.git
     echo "  teuthology_api:
         build:
-            context: ../../../../
+          context: ../../../../
         ports:
-            - 8082:8082
+            - 8082:8080
+        environment: 
+            TEUTHOLOGY_API_SERVER_HOST: 0.0.0.0
+            TEUTHOLOGY_API_SERVER_PORT: 8080
         depends_on:
             - teuthology
             - paddles
         links:
             - teuthology
             - paddles
+        healthcheck:
+          test: [ "CMD", "curl", "-f", "http://0.0.0.0:8082" ]
     " >> teuthology/docs/docker-compose/docker-compose.yml
 fi
 cd teuthology/docs/docker-compose

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,7 +2,9 @@ import os
 from multiprocessing import cpu_count
 
 
-bind = '0.0.0.0:8082'
+host = os.environ.get('TEUTHOLOGY_API_SERVER_HOST', '0.0.0.0')
+port = os.environ.get('TEUTHOLOGY_API_SERVER_PORT', '8080')
+bind = f'{host}:{port}'
  
 workers = cpu_count()
 worker_class = 'uvicorn.workers.UvicornWorker'

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,6 @@ class APISettings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
-    PADDLES_URL: str = "http://paddles:8080"
     # TODO: team names need to be changed below when created
     admin_team: str = "ceph"  # ceph's github team with *sudo* access to sepia
     teuth_team: str = "teuth"  # ceph's github team with access to sepia

--- a/src/services/helpers.py
+++ b/src/services/helpers.py
@@ -8,7 +8,7 @@ from requests.exceptions import HTTPError
 import teuthology
 import requests  # Note: import requests after teuthology
 
-PADDLES_URL = settings.PADDLES_URL
+PADDLES_URL = os.getenv("PADDLES_URL")
 
 log = logging.getLogger(__name__)
 

--- a/start_container.sh
+++ b/start_container.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -ex
+trap exit TERM
+
+HOST=${TEUTHOLOGY_API_SERVER_HOST:-"0.0.0.0"}
+PORT=${TEUTHOLOGY_API_SERVER_PORT:-"8080"}
+
+
+cd /teuthology_api/src/
+
+if [ "$DEPLOYMENT" = "development" ]; then
+  uvicorn main:app --reload --port $PORT --host $HOST
+else
+  gunicorn -c /teuthology_api/gunicorn_config.py main:app
+fi


### PR DESCRIPTION
- use `TEUTHOLOGY_API_SERVER_HOST` and `TEUTHOLOGY_API_SERVER_PORT` when starting the server to map host and port
- add start_container.sh
- if DEPLOYMENT=development, start reload server otherwise start gunicorn server
- read PADDLES_URL from env variable instead of src/config.py