### PR TITLE
fix pydantic ValidationError when loading .env file

### DIFF
--- a/src/teuthology_api/config.py
+++ b/src/teuthology_api/config.py
@@ -7,7 +7,9 @@ class APISettings(BaseSettings):
     Class for API settings.
     """
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
     # TODO: team names need to be changed below when created
     admin_team: str = "ceph"  # ceph's github team with *sudo* access to sepia
     teuth_team: str = "teuth"  # ceph's github team with access to sepia


### PR DESCRIPTION
By default extra=forbid is used, which raises ValidationError
when there are variables in .env which are not defined in 
`APISettings` as attributes.
Solution: extra=ignore would not raise errors for new env variables
in .env file and load all of them.
ref: https://docs.pydantic.dev/latest/concepts/pydantic_settings/#:~:text=you%20should%20use-,extra%3Dignore,-%3A

fixes: https://github.com/ceph/teuthology-api/issues/25