### PR TITLE
use config.settings attributes instead of os.getenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A REST API to execute [teuthology commands](https://docs.ceph.com/projects/teuth
     teuthology_api:
         build:
           context: ../../../teuthology-api
+        env_file: ../../../teuthology-api/.env
         ports:
             - 8082:8080
         environment:

--- a/src/teuthology_api/config.py
+++ b/src/teuthology_api/config.py
@@ -7,6 +7,18 @@ class APISettings(BaseSettings):
     Class for API settings.
     """
 
+    deployment: str = ""
+    pulpito_url: str = ""
+    paddles_url: str = ""
+
+    gh_client_id: str = ""
+    gh_client_secret: str = ""
+    gh_token_url: str = ""
+    gh_authorization_base_url: str = ""
+    gh_fetch_membership_url: str = ""
+
+    session_secret_key: str = ""
+
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra="ignore"
     )

--- a/src/teuthology_api/main.py
+++ b/src/teuthology_api/main.py
@@ -3,16 +3,15 @@ import os
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
-from dotenv import load_dotenv
 
+from teuthology_api.config import settings
 from teuthology_api.routes import suite, kill, login, logout
 
-load_dotenv()
 
-DEPLOYMENT = os.getenv("DEPLOYMENT")
-SESSION_SECRET_KEY = os.getenv("SESSION_SECRET_KEY")
-PULPITO_URL = os.getenv("PULPITO_URL")
-PADDLES_URL = os.getenv("PADDLES_URL")
+DEPLOYMENT = settings.deployment
+SESSION_SECRET_KEY = settings.session_secret_key
+PULPITO_URL = settings.pulpito_url
+PADDLES_URL = settings.paddles_url
 
 log = logging.getLogger(__name__)
 app = FastAPI()

--- a/src/teuthology_api/routes/login.py
+++ b/src/teuthology_api/routes/login.py
@@ -2,17 +2,16 @@ import logging
 import os
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from dotenv import load_dotenv
 import httpx
+from teuthology_api.config import settings
 
-load_dotenv()
 
-GH_CLIENT_ID = os.getenv("GH_CLIENT_ID")
-GH_CLIENT_SECRET = os.getenv("GH_CLIENT_SECRET")
-GH_AUTHORIZATION_BASE_URL = os.getenv("GH_AUTHORIZATION_BASE_URL")
-GH_TOKEN_URL = os.getenv("GH_TOKEN_URL")
-GH_FETCH_MEMBERSHIP_URL = os.getenv("GH_FETCH_MEMBERSHIP_URL")
-PULPITO_URL = os.getenv("PULPITO_URL")
+GH_CLIENT_ID = settings.gh_client_id
+GH_CLIENT_SECRET = settings.gh_client_secret
+GH_AUTHORIZATION_BASE_URL = settings.gh_authorization_base_url
+GH_TOKEN_URL = settings.gh_token_url
+GH_FETCH_MEMBERSHIP_URL = settings.gh_fetch_membership_url
+PULPITO_URL = settings.pulpito_url
 
 log = logging.getLogger(__name__)
 router = APIRouter(

--- a/src/teuthology_api/routes/logout.py
+++ b/src/teuthology_api/routes/logout.py
@@ -1,8 +1,9 @@
-import logging, os
+import logging
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
+from teuthology_api.config import settings
 
-PULPITO_URL = os.getenv("PULPITO_URL")
+PULPITO_URL = settings.pulpito_url
 log = logging.getLogger(__name__)
 
 router = APIRouter(

--- a/src/teuthology_api/services/helpers.py
+++ b/src/teuthology_api/services/helpers.py
@@ -11,7 +11,7 @@ import teuthology
 import requests  # Note: import requests after teuthology
 from requests.exceptions import HTTPError
 
-PADDLES_URL = os.getenv("PADDLES_URL")
+PADDLES_URL = settings.paddles_url
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
APISettings() will load all values from .env file as 
APISettings's attributes. These can be imported in all 
other modules, instead of using load_dotenv in every module. 
ref: https://fastapi.tiangolo.com/advanced/settings/#reading-a-env-file

This also fixes the issue of missing value of PADDLES_URL in services/helpers.py