### PR TITLE
start_container.sh: fix 'Could not import module "main"' for uvicorn server

### DIFF
--- a/start_container.sh
+++ b/start_container.sh
@@ -9,7 +9,7 @@ PORT=${TEUTHOLOGY_API_SERVER_PORT:-"8080"}
 cd /teuthology_api/src/
 
 if [ "$DEPLOYMENT" = "development" ]; then
-  uvicorn main:app --reload --port $PORT --host $HOST
+  uvicorn teuthology_api.main:app --reload --port $PORT --host $HOST
 else
   gunicorn -c /teuthology_api/gunicorn_config.py teuthology_api.main:app
 fi


### PR DESCRIPTION
fixes: https://github.com/ceph/teuthology-api/issues/35