### PR TITLE
use ARCHIVE_DIR env variable instead of hardcoding /archive_dir/

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -13,3 +13,6 @@ GH_FETCH_MEMBERSHIP_URL='https://api.github.com/user/memberships/orgs/ceph'
 ## SESSION_SECRET_KEY is used to encrypt session data
 ## and it's prod value should be kept secret.
 SESSION_SECRET_KEY=my-secret-key
+
+# Path where all logs for teuthology-suite or teuthology-kill would be collected
+ARCHIVE_DIR=/archive_dir/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ COPY .teuthology.yaml /root
 WORKDIR /teuthology_api
 COPY . /teuthology_api/
 RUN pip3 install -e .
+RUN mkdir /archive_dir/
 
 CMD sh /teuthology_api/start_container.sh

--- a/src/teuthology_api/config.py
+++ b/src/teuthology_api/config.py
@@ -18,6 +18,7 @@ class APISettings(BaseSettings):
     gh_fetch_membership_url: str = ""
 
     session_secret_key: str = ""
+    archive_dir: str = ""
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra="ignore"

--- a/src/teuthology_api/services/helpers.py
+++ b/src/teuthology_api/services/helpers.py
@@ -2,6 +2,7 @@ from multiprocessing import Process
 import logging
 import os
 import uuid
+from pathlib import Path
 
 from fastapi import HTTPException, Request
 
@@ -12,6 +13,7 @@ import requests  # Note: import requests after teuthology
 from requests.exceptions import HTTPError
 
 PADDLES_URL = settings.paddles_url
+ARCHIVE_DIR = settings.archive_dir
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +24,8 @@ def logs_run(func, args):
     and return logs printed during the execution of the function.
     """
     _id = str(uuid.uuid4())
-    log_file = f"/archive_dir/{_id}.log"
+    archive = Path(ARCHIVE_DIR)
+    log_file = archive / f"{_id}.log"
 
     teuthology_process = Process(target=_execute_with_logs, args=(func, args, log_file))
     teuthology_process.start()


### PR DESCRIPTION
In services/helpers.py, `logs_run` writes in hardcoded "/archive_dir/" path. Instead, use archive path from an environment variable `ARCHIVE_DIR`.
This fixes the problem when "/archive_dir" dir does not exist.