### PR TITLE
services/kill: make username check case-insensitive

### DIFF
--- a/src/teuthology_api/services/kill.py
+++ b/src/teuthology_api/services/kill.py
@@ -24,16 +24,16 @@ def run(args, send_logs: bool, access_token: str, request: Request):
     run_name = args.get("--run")
     if run_name:
         run_details = get_run_details(run_name)
-        run_username = run_details.get("user")
+        run_owner = run_details.get("user")
     else:
         log.error("teuthology-kill is missing --run")
         raise HTTPException(status_code=400, detail="--run is a required argument")
     # TODO if user has admin priviledge, then they can kill any run/job.
-    if run_username != username:
+    if run_owner.lower() != username.lower():
         log.error(
             "%s doesn't have permission to kill a job scheduled by: %s",
             username,
-            run_username,
+            run_owner,
         )
         raise HTTPException(
             status_code=401, detail="You don't have permission to kill this run/job"


### PR DESCRIPTION
Kill route checks if github_username == run_owner (from paddles). 
Github returns username like "JohnDoe" while run-names scheduled via teuthology machines have no capitalisation like "johndoe". This results in error like: `ERROR:teuthology_api.services.kill:JohnDoe doesn't have permission to kill a job scheduled by: johndoe`

Runs scheduled by teuthology-api would not have above error because they would have run-name capitalised too like "JohnDoe-2024-01-08_10:32:53-teuthology:no-ceph-main-distro-default-testnode". 




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [x] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [ ] Documentation updated
