### PR TITLE
setup.cfg & config.py: make sure we load_dotenv()

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     httpx
     itsdangerous
     pydantic-settings
+    python-dotenv
     # Temporarily, using teuthology without monkey patching the thread
     teuthology @ git+https://github.com/ceph/teuthology@teuth-api#egg=teuthology[test]"
     # Original: git+https://github.com/ceph/teuthology#egg=teuthology[test]

--- a/src/teuthology_api/config.py
+++ b/src/teuthology_api/config.py
@@ -1,5 +1,8 @@
 from functools import lru_cache
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 class APISettings(BaseSettings):


### PR DESCRIPTION
Currently, setup.cfg doesn't have python-dotenv
as a required dependency so we add that.

Moreover, in config.py we didn't really
load_dotenv() so we didn't actually load
.env into pydantic_settings

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [x] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [ ] Documentation updated
