### PR TITLE
Use teuthology-kill command instead of teuthology.kill.main function

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -16,3 +16,4 @@ SESSION_SECRET_KEY=my-secret-key
 
 # Path where all logs for teuthology-suite or teuthology-kill would be collected
 ARCHIVE_DIR=/archive_dir/
+TEUTHOLOGY_PATH=/teuthology

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ Example
         "--suite-repo": "https://github.com/ceph/ceph-ci.git",
         "--teuthology-branch": "main",
         "--verbose": "1",
-        "--user": "example"
+        "<config_yaml>": ["/teuthology/containerized_node.yaml"]
+        "--owner": "example",
      }'
 
-Note: "--user" in data body should be same as your github username (case sensitive). Otherwise, you wouldn't have permission to kill jobs/run.
+Note: "--owner" in data body should be same as your github username (case sensitive). Otherwise, you wouldn't have permission to kill jobs/run.
 
 xxx

--- a/src/teuthology_api/config.py
+++ b/src/teuthology_api/config.py
@@ -22,6 +22,7 @@ class APISettings(BaseSettings):
 
     session_secret_key: str = ""
     archive_dir: str = ""
+    teuthology_path: str = ""
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra="ignore"

--- a/src/teuthology_api/routes/kill.py
+++ b/src/teuthology_api/routes/kill.py
@@ -28,5 +28,5 @@ def create_run(
     or else it will SyntaxError: non-dafault
     argument follows default argument error.
     """
-    args = args.model_dump(by_alias=True)
+    args = args.model_dump(by_alias=True, exclude_unset=True)
     return run(args, logs, access_token, request)

--- a/src/teuthology_api/routes/suite.py
+++ b/src/teuthology_api/routes/suite.py
@@ -1,9 +1,9 @@
 import logging
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Request
 
 from teuthology_api.services.suite import run
-from teuthology_api.services.helpers import get_token
+from teuthology_api.services.helpers import get_token, get_username
 from teuthology_api.schemas.suite import SuiteArgs
 
 log = logging.getLogger(__name__)
@@ -17,10 +17,12 @@ router = APIRouter(
 
 @router.post("/", status_code=200)
 def create_run(
+    request: Request,
     args: SuiteArgs,
     access_token: str = Depends(get_token),
     dry_run: bool = False,
     logs: bool = False,
 ):
     args = args.model_dump(by_alias=True)
+    args["--user"] = get_username(request)
     return run(args, dry_run, logs, access_token)

--- a/src/teuthology_api/schemas/base.py
+++ b/src/teuthology_api/schemas/base.py
@@ -11,4 +11,3 @@ class BaseArgs(BaseModel):
     non_interactive: Union[bool, None] = Field(default=False, alias="--non-interactive")
     verbose: Union[int, None] = Field(default=1, alias="--verbose")
     help: Union[bool, None] = Field(default=False, alias="--help")
-    user: str = Field(alias="--user", description="Sepia username")

--- a/src/teuthology_api/services/kill.py
+++ b/src/teuthology_api/services/kill.py
@@ -1,11 +1,13 @@
-import teuthology.kill
 import logging
+import subprocess
 
 from fastapi import HTTPException, Request
 
-from teuthology_api.services.helpers import logs_run, get_username, get_run_details
+from teuthology_api.config import settings
+from teuthology_api.services.helpers import get_username, get_run_details
 
 
+TEUTHOLOGY_PATH = settings.teuthology_path
 log = logging.getLogger(__name__)
 
 
@@ -39,11 +41,23 @@ def run(args, send_logs: bool, access_token: str, request: Request):
             status_code=401, detail="You don't have permission to kill this run/job"
         )
     try:
+        kill_cmd = [f"{TEUTHOLOGY_PATH}/virtualenv/bin/teuthology-kill"]
+        for flag, flag_value in args.items():
+            if isinstance(flag_value, bool):
+                flag_value = int(flag_value)
+            kill_cmd += [flag, str(flag_value)]
+        log.info(kill_cmd)
+        proc = subprocess.Popen(
+            kill_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        stdout, stderr = proc.communicate()
+        returncode = proc.wait(timeout=120)
+        log.info(stdout)
+        if returncode != 0:
+            raise Exception(stdout)
         if send_logs:
-            logs = logs_run(teuthology.kill.main, args)
-            return {"logs": logs}
-        teuthology.kill.main(args)
+            return {"kill": "success", "logs": stdout}
         return {"kill": "success"}
     except Exception as exc:
-        log.error("teuthology.kill.main failed with the error: %s", repr(exc))
+        log.error("teuthology-kill command failed with the error: %s", repr(exc))
         raise HTTPException(status_code=500, detail=repr(exc)) from exc

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -20,7 +20,6 @@ mock_kill_args = {
     "--non-interactive": False,
     "--verbose": 1,
     "--help": False,
-    "--user": "mock_user",
     "--owner": "user1",
     "--run": "mock_run",
     "--preserve-queue": None,
@@ -31,13 +30,15 @@ mock_kill_args = {
 }
 
 
-@patch("teuthology_api.services.kill.teuthology.kill.main")
+@patch("subprocess.Popen")
 @patch("teuthology_api.services.kill.get_run_details")
 @patch("teuthology_api.services.kill.get_username")
-def test_kill_run_success(m_get_username, m_get_run_details, m_teuth_kill_main):
+def test_kill_run_success(m_get_username, m_get_run_details, m_popen):
     m_get_username.return_value = "user1"
     m_get_run_details.return_value = {"id": "7451978", "user": "user1"}
-    m_teuth_kill_main.return_value = None
+    mock_process = m_popen.return_value
+    mock_process.communicate.return_value = ("logs", "")
+    mock_process.wait.return_value = 0
     response = client.post("/kill", data=json.dumps(mock_kill_args))
     assert response.status_code == 200
     assert response.json() == {"kill": "success"}

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -19,7 +19,6 @@ mock_suite_args = {
     "--non-interactive": False,
     "--verbose": 1,
     "--help": False,
-    "--user": "mock_user",
     "--timestamp": "2023-10-21_14:30:00",
     "--owner": "user1",
     "--suite": "rados",
@@ -31,8 +30,10 @@ mock_suite_args = {
 
 # suite
 @patch("teuthology_api.services.suite.teuthology.suite.main")
+@patch("teuthology_api.routes.suite.get_username")
 @patch("teuthology_api.services.suite.get_run_details")
-def test_suite_run_success(m_get_run_details, m_teuth_suite_main):
+def test_suite_run_success(m_get_run_details, m_get_username, m_teuth_suite_main):
+    m_get_username.return_value = "user1"
     m_get_run_details.return_value = {"id": "7451978", "user": "user1"}
     response = client.post("/suite", data=json.dumps(mock_suite_args))
     assert response.status_code == 200


### PR DESCRIPTION
To test this PR, setup teuthology-api inside the teuthology container. 
1. Add instructions in teuthology dockerfile to setup t-api inside the teuthology container:
```
SHELL ["/bin/bash", "-c"] 
WORKDIR /
RUN git clone -b use-kill-cmd https://github.com/ceph/teuthology-api && \
    cd /teuthology-api/ && \
    python3 -m venv venv && source ./venv/bin/activate && pip install -e . && \
    export TEUTHOLOGY_API_SERVER_PORT=8083 && \
    exit
WORKDIR /teuthology
....
```
2. In docker-compose file, expose TEUTHOLOGY_API_SERVER_PORT for teuthology service:
```
teuthology:
   ports:
      - 8083:8083
```
3. Start the containers
4. exec into the teuthology container and run these commands:
```
cd /teuthology-api
source ./venv/bin/activate
<add your teuthology-api's .env file>
uvicorn teuthology_api.main:app --reload --port 8083 --host 0.0.0.0
```

5. Schedule a run on /suite route, using the README payload. 
6. Then kill by pressing "Kill Run" button of https://github.com/ceph/pulpito-ng/pull/51



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [x] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [x] Includes tests
- [x] Documentation updated
