### PR TITLE
suite: remove "dry_run" query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,12 @@ Returns `{"root": "success", "session": { <authentication details> }}`.
 
 POST `/suite/`: schedules a run.
 
-Two query parameters:
-- `dry_run` (boolean) - Do a dry run; do not schedule anything.
+Query parameters:
 - `logs` (boolean) - Send scheduling logs in response.
 
 Example
 
-    curl --location --request POST 'http://localhost:8082/suite?dry_run=false&logs=true' \
+    curl --location --request POST 'http://localhost:8082/suite&logs=true' \
     --header 'Content-Type: application/json' \
     --data-raw '{
         "--ceph": "main",
@@ -101,10 +100,10 @@ Example
         "--suite": "teuthology:no-ceph",
         "--suite-branch": "main",
         "--suite-repo": "https://github.com/ceph/ceph-ci.git",
-        "--teuthology-branch": "main",
+        "--teuthology-branch": "", // necessary for docker setup
         "--verbose": "1",
-        "<config_yaml>": ["/teuthology/containerized_node.yaml"]
-        "--owner": "example",
+        "<config_yaml>": ["/teuthology/containerized_node.yaml"],
+        "--owner": "example"
      }'
 
 Note: "--owner" in data body should be same as your github username (case sensitive). Otherwise, you wouldn't have permission to kill jobs/run.

--- a/src/teuthology_api/routes/suite.py
+++ b/src/teuthology_api/routes/suite.py
@@ -20,9 +20,8 @@ def create_run(
     request: Request,
     args: SuiteArgs,
     access_token: str = Depends(get_token),
-    dry_run: bool = False,
     logs: bool = False,
 ):
     args = args.model_dump(by_alias=True)
     args["--user"] = get_username(request)
-    return run(args, dry_run, logs, access_token)
+    return run(args, logs, access_token)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -29,15 +29,15 @@ mock_suite_args = {
 }
 
 # suite
-@patch("teuthology_api.services.suite.teuthology.suite.main")
+@patch("teuthology_api.services.suite.logs_run")
 @patch("teuthology_api.routes.suite.get_username")
 @patch("teuthology_api.services.suite.get_run_details")
-def test_suite_run_success(m_get_run_details, m_get_username, m_teuth_suite_main):
+def test_suite_run_success(m_get_run_details, m_get_username, m_logs_run):
     m_get_username.return_value = "user1"
     m_get_run_details.return_value = {"id": "7451978", "user": "user1"}
     response = client.post("/suite", data=json.dumps(mock_suite_args))
     assert response.status_code == 200
-    assert response.json() == {"run": {"id": "7451978", "user": "user1"}, "logs": []}
+    assert response.json() == {"run": {"id": "7451978", "user": "user1"}}
 
 
 # make_run_name


### PR DESCRIPTION
Build on top of `use-kill-cmd` branch (that has a commit which removes "--user" from schema). 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [x] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [x] Includes tests
- [x] Documentation updated
