### PR TITLE
[suite]: Modify how we handle Error and Success runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ MANIFEST
 .conda*/
 .python-version
 venv
+.env

--- a/src/teuthology_api/routes/suite.py
+++ b/src/teuthology_api/routes/suite.py
@@ -24,4 +24,9 @@ def create_run(
 ):
     args = args.model_dump(by_alias=True)
     args["--user"] = get_username(request)
-    return run(args, logs, access_token)
+    try:
+        created_run = run(args, logs, access_token)
+        log.debug(created_run)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return created_run

--- a/src/teuthology_api/schemas/suite.py
+++ b/src/teuthology_api/schemas/suite.py
@@ -37,7 +37,7 @@ class SuiteArgs(BaseArgs):
         default="https://github.com/ceph/ceph-ci.git", alias="--suite-repo"
     )
     teuthology_branch: Union[str, None] = Field(
-        default="main", alias="--teuthology-branch"
+        default=None, alias="--teuthology-branch"
     )
     validate_sha1: Union[str, None] = Field(default="true", alias="--validate-sha1")
     wait: Union[bool, None] = Field(default=False, alias="--wait")

--- a/src/teuthology_api/services/helpers.py
+++ b/src/teuthology_api/services/helpers.py
@@ -1,4 +1,4 @@
-from multiprocessing import Process
+from multiprocessing import Process, Queue
 import logging
 import os
 import uuid
@@ -32,26 +32,44 @@ def logs_run(func, args):
     _id = str(uuid.uuid4())
     archive = Path(ARCHIVE_DIR)
     log_file = archive / f"{_id}.log"
-
-    teuthology_process = Process(target=_execute_with_logs, args=(func, args, log_file))
-    teuthology_process.start()
-    teuthology_process.join()
-
+    teuth_queue = Queue()
+    teuth_process = Process(
+        target=_execute_with_logs, args=(func, args, log_file, teuth_queue)
+    )
+    teuth_process.daemon = True  # Set the process as a daemon
+    teuth_process.start()
+    teuth_process.join(timeout=180)  # Set the timeout value in seconds
+    if teuth_process.is_alive():
+        teuth_process.terminate()  # Terminate the process if it exceeds the timeout
+        teuth_process.join()
+        raise TimeoutError("Process execution timed out")
     logs = ""
     with open(log_file, encoding="utf-8") as file:
         logs = file.readlines()
     if os.path.isfile(log_file):
         os.remove(log_file)
-    return logs
+    log.debug(logs)
+    if teuth_process.exitcode > 0:
+        e = teuth_queue.get()
+        log.error(e)
+        return "fail", e, 0
+    else:
+        job_count = teuth_queue.get()
+        return "success", logs, job_count
 
 
-def _execute_with_logs(func, args, log_file):
+def _execute_with_logs(func, args, log_file, teuth_queue):
     """
     To store logs, set a new FileHandler for teuthology root logger
     and then execute the command function.
     """
     teuthology.setup_log_file(log_file)
-    func(args)
+    try:
+        job_count = func(args)
+        teuth_queue.put(job_count)
+    except Exception as e:
+        teuth_queue.put(e)
+        raise
 
 
 def get_run_details(run_name: str):

--- a/src/teuthology_api/services/suite.py
+++ b/src/teuthology_api/services/suite.py
@@ -23,7 +23,11 @@ def run(args, send_logs: bool, access_token: str):
     try:
         args["--timestamp"] = datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
 
-        logs = logs_run(teuthology.suite.main, args)
+        status, logs, job_count = logs_run(teuthology.suite.main, args)
+        if status == "fail":
+            raise logs
+        if args["--dry-run"] or job_count < 1:
+            return {"run": {}, "logs": logs, "job_count": job_count}
 
         # get run details from paddles
         run_name = make_run_name(
@@ -38,12 +42,13 @@ def run(args, send_logs: bool, access_token: str):
             }
         )
         run_details = get_run_details(run_name)
-        if send_logs or args["--dry-run"]:
-            return {"run": run_details, "logs": logs}
-        return {"run": run_details}
+        if send_logs:
+            return {"run": run_details, "logs": logs, "job_count": job_count}
+        else:
+            return {"run": run_details, "job_count": job_count}
     except Exception as exc:
         log.error("teuthology.suite.main failed with the error: %s", repr(exc))
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=repr(exc)) from exc
 
 
 def make_run_name(run_dic):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 from teuthology_api.main import app
 from unittest.mock import patch
 from teuthology_api.services.helpers import get_token
-from teuthology_api.services.suite import make_run_name, get_run_details
+from teuthology_api.services.suite import make_run_name
 import json
 
 client = TestClient(app)
@@ -29,15 +29,18 @@ mock_suite_args = {
 }
 
 # suite
+
+
 @patch("teuthology_api.services.suite.logs_run")
 @patch("teuthology_api.routes.suite.get_username")
 @patch("teuthology_api.services.suite.get_run_details")
 def test_suite_run_success(m_get_run_details, m_get_username, m_logs_run):
+    m_logs_run.return_value = ("success", "example logs", 1)
     m_get_username.return_value = "user1"
     m_get_run_details.return_value = {"id": "7451978", "user": "user1"}
     response = client.post("/suite", data=json.dumps(mock_suite_args))
     assert response.status_code == 200
-    assert response.json() == {"run": {"id": "7451978", "user": "user1"}}
+    assert response.json() == {"run": {"id": "7451978", "user": "user1"}, "job_count": 1}
 
 
 # make_run_name


### PR DESCRIPTION
### Merge https://github.com/ceph/teuthology/pull/1924 first before this PR

As per As per: https://github.com/ceph/pulpito-ng/pull/23
The changes includes:

1. make suite route return
{"run": run_details, "logs": logs, "job_count": job_count}

2. Improve how we handle Exception by utilizing Queue from
python multiprocessing library.

3. Set the timeout for the process to be 180 seconds, if teuthology
doesn't respond back within that time, then we return a Process Timeout

4. Add .env to gitignore

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [x] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [ ] Documentation updated
