### PR TITLE
routes/suite.py: add /default endpoint

### DIFF
--- a/src/teuthology_api/routes/suite.py
+++ b/src/teuthology_api/routes/suite.py
@@ -25,3 +25,14 @@ def create_run(
     args = args.model_dump(by_alias=True)
     args["--user"] = get_username(request)
     return run(args, logs, access_token)
+
+
+@router.get("/default", status_code=200)
+def default_values(request: Request):
+    args = {
+        "--suite": "teuthology:no-ceph",
+        "--machine-type": None,
+        "--owner": get_username(request),
+    }
+    default = SuiteArgs(**args)
+    return default.model_dump(by_alias=True)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -41,8 +41,6 @@ def test_suite_run_success(m_get_run_details, m_get_username, m_logs_run):
 
 
 # make_run_name
-
-
 def test_make_run_name():
     m_run_dic = {
         "user": "testuser",
@@ -101,3 +99,60 @@ def test_make_run_name_with_no_kernel_branch():
         "teuthology-2022-03-21_14:30:00-rados-ceph1-distro-test-flavor-test-machine"
     )
     assert make_run_name(m_run_dic) == expected
+
+
+@patch("teuthology_api.routes.suite.get_username")
+def test_default_suite_args(m_get_username):
+    m_get_username.return_value = "user1"
+    m_default_args = {
+        "--dry-run": False,
+        "--non-interactive": False,
+        "--verbose": 1,
+        "--help": False,
+        "--arch": None,
+        "--ceph": "main",
+        "--ceph-repo": "https://github.com/ceph/ceph-ci.git",
+        "--distro": None,
+        "--distro-version": None,
+        "--email": None,
+        "--flavor": "default",
+        "--kernel": "distro",
+        "--machine-type": None,
+        "--newest": "0",
+        "--rerun-status.": False,
+        "--rerun-statuses": "fail,dead",
+        "--sha1": None,
+        "--sleep-before-teardown": "0",
+        "--suite": "teuthology:no-ceph",
+        "--suite-branch": None,
+        "--suite-dir": None,
+        "--suite-relpath": "qa",
+        "--suite_repo": "https://github.com/ceph/ceph-ci.git",
+        "--teuthology-branch": "main",
+        "--validate-sha1": "true",
+        "--wait": False,
+        "<config_yaml>": [],
+        "--owner": "user1",
+        "--num": "1",
+        "--priority": "70",
+        "--queue-backend": None,
+        "--rerun": None,
+        "--seed": "-1",
+        "--force-priority": False,
+        "--no-nested-subset": False,
+        "--job-threshold": "500",
+        "--archive-upload": None,
+        "--archive-upload-url": None,
+        "--throttle": None,
+        "--filter": None,
+        "--filter-out": None,
+        "--filter-all": None,
+        "--filter-fragments": "false",
+        "--subset": None,
+        "--timeout": "43200",
+        "--rocketchat": None,
+        "--limit": "0",
+    }
+    response = client.get("/suite/default")
+    assert response.status_code == 200
+    assert response.json() == m_default_args


### PR DESCRIPTION
**Evaluation task for Google Summer of Code 2024**
- [x] Setup [teuthology-api](https://github.com/ceph/teuthology-api) and share screenshot that you're able to schedule runs from teuthology-api  (i.e. share screenshot of success response for /suite endpoint)

![image](https://github.com/ceph/teuthology-api/assets/58616444/95c6a772-e0f2-4769-9fda-4ab1ac4aa307)

- [x] Open a PR for adding a new endpoint to teuthology-api for suite command defaults: https://github.com/ceph/pulpito-ng/issues/41
- [x] [optional] Add unit tests for the new endpoint added above
- [x] Understanding of current build-and-schedule workflow and new auto-schedule workflow in proposal

## Checklist
- [x] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [x] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [x] Includes tests
- [ ] Documentation updated
