### PR TITLE
Fix CI Integration test and unit test

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -3,8 +3,13 @@ on: pull_request
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    name: Unit Tests on python${{ matrix.python }} via ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            python: "3.10"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND=noninteractive
+ENV VENV=${VENV:-"venv"}
 RUN apt-get update && \
     apt-get install -y \
     git \
@@ -21,7 +22,8 @@ RUN apt-get update && \
 COPY .teuthology.yaml /root
 WORKDIR /teuthology_api
 COPY . /teuthology_api/
-RUN pip3 install -e .
+RUN python3 -m venv ${VENV}
+RUN /teuthology_api/${VENV}/bin/pip3 install -e .
 RUN mkdir /archive_dir/
 
-CMD sh /teuthology_api/start_container.sh
+ENTRYPOINT /teuthology_api/start_container.sh

--- a/start_container.sh
+++ b/start_container.sh
@@ -1,11 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/bash
 set -ex
 trap exit TERM
 
 HOST=${TEUTHOLOGY_API_SERVER_HOST:-"0.0.0.0"}
 PORT=${TEUTHOLOGY_API_SERVER_PORT:-"8082"}
+VENV=${VENV:-"venv"}
 
-
+source ${VENV}/bin/activate
 cd /teuthology_api/src/
 
 if [ "$DEPLOYMENT" = "development" ]; then


### PR DESCRIPTION
1. Fix integration test CI

  In Dockefile, use base image 'ubuntu:jammy' instead of focal.

  Reason: 
  Default python version in focal is python3.8 which is breaking
  integration CI builds on t-api PRs with:
  `ERROR: Package 'teuthology-1.1.1.dev729-g861a8dcf' requires a different Python: 3.8.10 not in '>=3.10'`

  Recently, we upgraded the minimum teuthology version to support
  python3.10, which could be the reason of the above CI failures.

2. Fix unit test CI

Use ubuntu-22.04 and python 3.10


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [ ] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [ ] Documentation updated
