### PR TITLE
.github/workflows: add container.yaml

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,34 @@
+# Automatically update teuthology-api:main image on quay.io/ceph-infra/teuthology-api
+name: Push Container to Quay
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # QUAY_URI is set using https://github.com/ceph/teuthology-api/settings/variables/actions
+          tags: ${{ vars.QUAY_URI }}:${{ github.ref_name }}
+          outputs: type=image,name=target


### PR DESCRIPTION
Automatically update teuthology-api:main
image to QUAY_URI (set from github repo settings).

Tested here: https://quay.io/repository/rh-ee-vaagrawa/teuthology-api?tab=tags

TODO: 
1. ~~Merge https://github.com/ceph/teuthology-api/pull/58~~
2. I have added my quay's credentials in repo settings. These need to be changed to ceph-infra's creds. 
   Things to be changed in github repo settings (https://github.com/ceph/teuthology-api/settings/variables/actions):
   secrets: `QUAY_USERNAME`, `QUAY_ROBOT_TOKEN`
   env variable: `QUAY_URI`



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [ ] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [ ] Documentation updated
