### PR TITLE
Disabled github auth for dev setup and set up default as development

### DIFF
--- a/src/teuthology_api/main.py
+++ b/src/teuthology_api/main.py
@@ -9,7 +9,7 @@ from teuthology_api.routes import suite, kill, login, logout
 
 load_dotenv()
 
-DEPLOYMENT = os.getenv("DEPLOYMENT")
+DEPLOYMENT = os.getenv("DEPLOYMENT", "production")
 SESSION_SECRET_KEY = os.getenv("SESSION_SECRET_KEY")
 PULPITO_URL = os.getenv("PULPITO_URL")
 PADDLES_URL = os.getenv("PADDLES_URL")
@@ -26,6 +26,7 @@ def read_root(request: Request):
     return {"root": "success", "session": request.session.get("user", None)}
 
 
+
 if DEPLOYMENT == "development":
     app.add_middleware(
         CORSMiddleware,
@@ -35,7 +36,12 @@ if DEPLOYMENT == "development":
         allow_headers=["*"],
     )
 
-app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET_KEY)
+
+if SESSION_SECRET_KEY:
+    app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET_KEY)
+else:
+    log.warning("SESSION_SECRET_KEY is not set. Sessions are disabled.")
+
 app.include_router(suite.router)
 app.include_router(kill.router)
 app.include_router(login.router)

--- a/src/teuthology_api/main.py
+++ b/src/teuthology_api/main.py
@@ -9,7 +9,7 @@ from teuthology_api.routes import suite, kill, login, logout
 
 load_dotenv()
 
-DEPLOYMENT = os.getenv("DEPLOYMENT", "production")
+DEPLOYMENT = os.getenv("DEPLOYMENT", "development")
 SESSION_SECRET_KEY = os.getenv("SESSION_SECRET_KEY")
 PULPITO_URL = os.getenv("PULPITO_URL")
 PADDLES_URL = os.getenv("PADDLES_URL")

--- a/src/teuthology_api/services/helpers.py
+++ b/src/teuthology_api/services/helpers.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 PADDLES_URL = os.getenv("PADDLES_URL")
 ARCHIVE_DIR = os.getenv("ARCHIVE_DIR")
-DEPLOYMENT = os.getenv("DEPLOYMENT", "production")  
+DEPLOYMENT = os.getenv("DEPLOYMENT", "development")  
 
 log = logging.getLogger(__name__)
 

--- a/src/teuthology_api/services/helpers.py
+++ b/src/teuthology_api/services/helpers.py
@@ -1,27 +1,25 @@
-from multiprocessing import Process
 import logging
 import os
 import uuid
 from pathlib import Path
-
 from fastapi import HTTPException, Request
 from dotenv import load_dotenv
-
 import teuthology
-import requests  # Note: import requests after teuthology
+import requests  
 from requests.exceptions import HTTPError
 
 load_dotenv()
 
 PADDLES_URL = os.getenv("PADDLES_URL")
 ARCHIVE_DIR = os.getenv("ARCHIVE_DIR")
+DEPLOYMENT = os.getenv("DEPLOYMENT", "production")  
 
 log = logging.getLogger(__name__)
 
 
 def logs_run(func, args):
     """
-    Run the command function in a seperate process (to isolate logs),
+    Run the command function in a separate process (to isolate logs),
     and return logs printed during the execution of the function.
     """
     _id = str(uuid.uuid4())
@@ -70,8 +68,11 @@ def get_run_details(run_name: str):
 
 def get_username(request: Request):
     """
-    Get username from request.session
+    Get username from request.session, bypass authentication if in development.
     """
+    if DEPLOYMENT == "development":
+        return "dev_user"
+    
     username = request.session.get("user", {}).get("username")
     if username:
         return username
@@ -85,8 +86,11 @@ def get_username(request: Request):
 
 def get_token(request: Request):
     """
-    Get access token from request.session
+    Get access token from request.session, bypass authentication if in development.
     """
+    if DEPLOYMENT == "development":
+        return {"access_token": "dev_token", "token_type": "bearer"}
+
     token = request.session.get("user", {}).get("access_token")
     if token:
         return {"access_token": token, "token_type": "bearer"}

--- a/src/teuthology_api/services/kill.py
+++ b/src/teuthology_api/services/kill.py
@@ -15,7 +15,7 @@ def run(args, send_logs: bool, access_token: str, request: Request):
     """
     Kill running teuthology jobs.
     """
-    deployment_env = os.getenv('DEPLOYMENT', 'production')
+    deployment_env = os.getenv('DEPLOYMENT', 'development')
     if deployment_env != 'development' and not access_token:
         log.error("access_token empty, user probably is not logged in.")
         raise HTTPException(

--- a/src/teuthology_api/services/suite.py
+++ b/src/teuthology_api/services/suite.py
@@ -15,7 +15,7 @@ def run(args, send_logs: bool, access_token: str):
     Schedule a suite.
     :returns: Run details (dict) and logs (list).
     """
-    deployment_env = os.getenv('DEPLOYMENT', 'production')
+    deployment_env = os.getenv('DEPLOYMENT', 'development')
     if deployment_env != 'development' and not access_token:
         raise HTTPException(
             status_code=401,

--- a/src/teuthology_api/services/suite.py
+++ b/src/teuthology_api/services/suite.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
 import teuthology.suite
+import os
 
 from fastapi import HTTPException
 
@@ -14,7 +15,8 @@ def run(args, send_logs: bool, access_token: str):
     Schedule a suite.
     :returns: Run details (dict) and logs (list).
     """
-    if not access_token:
+    deployment_env = os.getenv('DEPLOYMENT', 'production')
+    if deployment_env != 'development' and not access_token:
         raise HTTPException(
             status_code=401,
             detail="You need to be logged in",
@@ -25,7 +27,7 @@ def run(args, send_logs: bool, access_token: str):
 
         logs = logs_run(teuthology.suite.main, args)
 
-        # get run details from paddles
+        
         run_name = make_run_name(
             {
                 "machine_type": args["--machine-type"],


### PR DESCRIPTION
## Disabled github auth for dev setup and set up default as development
Fixes #66 
Changed and removed github auth for development in suite.py route, main.py and the services part.
The access_token check is skipped during dev setup.
By default deployment is set to development if not explicitly mentioned



## Checklist
- [ ] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [x] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [x] Documentation updated
