### PR TITLE
 Disabled github auth for dev setup and set up default as development #66

### DIFF
--- a/src/teuthology_api/main.py
+++ b/src/teuthology_api/main.py
@@ -35,7 +35,10 @@ if DEPLOYMENT == "development":
         allow_headers=["*"],
     )
 
-app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET_KEY)
+if SESSION_SECRET_KEY:
+    app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET_KEY)
+else:
+    log.warning("SESSION_SECRET_KEY is not set. Sessions are disabled.")
 app.include_router(suite.router)
 app.include_router(kill.router)
 app.include_router(login.router)

--- a/src/teuthology_api/routes/suite.py
+++ b/src/teuthology_api/routes/suite.py
@@ -1,5 +1,4 @@
 import logging
-
 from fastapi import APIRouter, HTTPException, Depends, Request
 
 from teuthology_api.services.suite import run
@@ -15,6 +14,7 @@ router = APIRouter(
 )
 
 
+
 @router.post("/", status_code=200)
 def create_run(
     request: Request,
@@ -22,6 +22,13 @@ def create_run(
     access_token: str = Depends(get_token),
     logs: bool = False,
 ):
-    args = args.model_dump(by_alias=True)
-    args["--user"] = get_username(request)
-    return run(args, logs, access_token)
+    try:
+        args = args.model_dump(by_alias=True)
+        args["--user"] = get_username(request)
+        return run(args, logs, access_token)
+    except HTTPException as exc:
+        log.error(f"HTTP exception occurred: {exc.detail}")
+        raise
+    except Exception as exc:
+        log.error(f"Unexpected error occurred: {repr(exc)}")
+        raise HTTPException(status_code=500, detail="An unexpected error occurred.")

--- a/src/teuthology_api/services/helpers.py
+++ b/src/teuthology_api/services/helpers.py
@@ -16,12 +16,13 @@ load_dotenv()
 PADDLES_URL = os.getenv("PADDLES_URL")
 ARCHIVE_DIR = os.getenv("ARCHIVE_DIR")
 
+DEPLOYMENT = os.getenv("DEPLOYMENT")
 log = logging.getLogger(__name__)
 
 
 def logs_run(func, args):
     """
-    Run the command function in a seperate process (to isolate logs),
+    Run the command function in a separate process (to isolate logs),
     and return logs printed during the execution of the function.
     """
     _id = str(uuid.uuid4())
@@ -72,6 +73,8 @@ def get_username(request: Request):
     """
     Get username from request.session
     """
+    if DEPLOYMENT == "development":
+        return "dev_user"
     username = request.session.get("user", {}).get("username")
     if username:
         return username
@@ -87,6 +90,8 @@ def get_token(request: Request):
     """
     Get access token from request.session
     """
+    if DEPLOYMENT == "development":
+        return {"access_token": "dev_token", "token_type": "bearer"}
     token = request.session.get("user", {}).get("access_token")
     if token:
         return {"access_token": token, "token_type": "bearer"}


### PR DESCRIPTION
## Disabled github auth for dev setup and set up default as development
Fixes #66 
Changed and removed github auth for development in suite.py route, main.py and the services part.
The access_token check is skipped during dev setup.
By default deployment is set to development if not explicitly mentioned



## Checklist
- [ ] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [x] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [x] Documentation updated
