### PR TITLE
[DNM] setup.cfs: use no-patch-threads branch of teuthology

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     httpx
     itsdangerous
     python-dotenv
-    teuthology @ git+https://github.com/ceph/teuthology#egg=teuthology[test]
+    teuthology @ git+https://github.com/vallariag/teuthology.git@no-patch-threads#egg=teuthology[test]
 
 
 [options.packages.find]


### PR DESCRIPTION
Testing unit test fix by using teuthology with a new commit: https://github.com/VallariAg/teuthology/commit/b7e20cb68d43baf9e33989d31c80521c9298342f.

To understand the cause of problem...
I created a new file test_new:
```
from fastapi import FastAPI
from fastapi.testclient import TestClient

app = FastAPI()


@app.get("/")
async def read_main():
    return {"msg": "Hello World"}


client = TestClient(app)


def test_read_main():
    response = client.get("/")
    assert response.status_code == 200
    assert response.json() == {"msg": "Hello World"}
```
and ran `pytest tests/test_new.py::test_read_main --full-trace`
Then added `import teuthology` to the file and it starts hanging!

With --full-trace, I get a gevent traceback. Which means teuthology and TestClient are clashing somehow. 
I've seen these gevent problems before with teuthology import. Not patching threads in teuthology fixed it. 

So testing it again here.  

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [ ] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [ ] Includes tests
- [ ] Documentation updated
