### PR TITLE
.github/workflows/unit_tests.yaml: run in path /teuthology_api

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -12,6 +12,8 @@ jobs:
             python: "3.10"
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: teuthology_api
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -21,3 +23,4 @@ jobs:
       - name: Run tox
         # Run tox using the version of Python in `PATH`
         run: tox -e py
+        working-directory: teuthology_api


### PR DESCRIPTION
This is because teuthology does not monkey patch threads if args have "teuthology_api": https://github.com/ceph/teuthology/blob/029bda193b1d38b67b279eb5c1037caa8408be24/teuthology/__init__.py#L29

The reason the unit test passed in container is because Dockerfile copies all files in /teuthology_api
```
COPY . /teuthology_api/
```
so teuthology package sees that in args and doesn't monkey patch threads. And locally, it sees "teuthology-api".


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [Issue/Tracker URL]
      Signed-off-by: [Your Name] <[your email]>

-->


## Contribution Guidelines

To sign and test your commits, please refer to [Contibution guidelines](./../CONTRIBUTING.md).

## Checklist
- [ ] Changes tested in [container setup](./../README.md#option-1-teuthology-docker-setup)
- [ ] Changes tested in [non-containerized setup](./../README.md#option-2-non-containerized-with-venv-and-pip)
- [x] Includes tests
- [ ] Documentation updated
